### PR TITLE
Add Redis-backed cache DAO using Spring Data Redis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,16 +17,21 @@
 		<java.version>17</java.version>
 	</properties>
 	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-data-redis</artifactId>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/example/cache/controller/CacheController.java
+++ b/src/main/java/com/example/cache/controller/CacheController.java
@@ -3,7 +3,6 @@ package com.example.cache.controller;
 import java.util.Map;
 
 import com.example.cache.dao.CacheDao;
-import com.example.cache.dao.impl.HashMapCacheDao;
 import com.example.cache.dto.KeyValuePair;
 import com.example.cache.exception.KeyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/example/cache/dao/impl/RedisCacheDao.java
+++ b/src/main/java/com/example/cache/dao/impl/RedisCacheDao.java
@@ -1,0 +1,32 @@
+package com.example.cache.dao.impl;
+
+import com.example.cache.dao.CacheDao;
+import com.example.cache.exception.KeyNotFoundException;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@Primary
+public class RedisCacheDao implements CacheDao {
+
+    private final StringRedisTemplate redisTemplate;
+
+    public RedisCacheDao(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    @Override
+    public void put(String key, String value) {
+        redisTemplate.opsForValue().set(key, value);
+    }
+
+    @Override
+    public String get(String key) throws KeyNotFoundException {
+        String value = redisTemplate.opsForValue().get(key);
+        if (value == null) {
+            throw new KeyNotFoundException(key);
+        }
+        return value;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 
+spring.redis.host=localhost
+spring.redis.port=6379


### PR DESCRIPTION
## Summary
- add Spring Data Redis dependency and configure default Redis host/port
- provide a Redis-backed CacheDao implementation that delegates to StringRedisTemplate
- clean up the controller to rely on the CacheDao abstraction

## Testing
- mvn -q -DskipTests package *(fails: unable to download parent POM due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68f63cc8ec388322892f5ac2d97d1127