### PR TITLE
Add unit tests for cache DAO and controller

### DIFF
--- a/src/test/java/com/example/cache/controller/CacheControllerTest.java
+++ b/src/test/java/com/example/cache/controller/CacheControllerTest.java
@@ -1,0 +1,59 @@
+package com.example.cache.controller;
+
+import com.example.cache.dao.CacheDao;
+import com.example.cache.exception.KeyNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CacheController.class)
+class CacheControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CacheDao cacheDao;
+
+    @Test
+    void putShouldStoreValueThroughDao() throws Exception {
+        mockMvc.perform(post("/put")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"key\":\"alpha\",\"value\":\"beta\"}"))
+                .andExpect(status().isCreated());
+
+        verify(cacheDao).put(eq("alpha"), eq("beta"));
+    }
+
+    @Test
+    void getShouldReturnValueFromDao() throws Exception {
+        when(cacheDao.get("k"))
+                .thenReturn("v");
+
+        mockMvc.perform(get("/get")
+                        .param("key", "k"))
+                .andExpect(status().isOk())
+                .andExpect(content().json("{\"k\":\"v\"}"));
+    }
+
+    @Test
+    void getShouldReturnNotFoundWhenDaoThrowsKeyNotFound() throws Exception {
+        when(cacheDao.get("missing"))
+                .thenThrow(new KeyNotFoundException("missing"));
+
+        mockMvc.perform(get("/get")
+                        .param("key", "missing"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/com/example/cache/dao/impl/HashMapCacheDaoTest.java
+++ b/src/test/java/com/example/cache/dao/impl/HashMapCacheDaoTest.java
@@ -1,0 +1,32 @@
+package com.example.cache.dao.impl;
+
+import com.example.cache.exception.KeyNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class HashMapCacheDaoTest {
+
+    private HashMapCacheDao dao;
+
+    @BeforeEach
+    void setUp() {
+        dao = new HashMapCacheDao();
+    }
+
+    @Test
+    void putAndGetShouldReturnStoredValue() throws KeyNotFoundException {
+        dao.put("foo", "bar");
+
+        String value = dao.get("foo");
+
+        assertEquals("bar", value, "Stored value should be returned when key exists");
+    }
+
+    @Test
+    void getMissingKeyShouldThrowException() {
+        assertThrows(KeyNotFoundException.class, () -> dao.get("missing"));
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests covering the HashMap-backed cache DAO
- add MockMvc-based tests for the cache controller endpoints

## Testing
- mvn test *(fails: unable to download Spring Boot parent POM from Maven Central – HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68f6517e32e48322ae2d7ea56731bdb1