### PR TITLE
Add README describing cache performance focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Spring Performance Cache
+
+This project provides a cache layer exposed through HTTP endpoints that can be backed by multiple storage implementations. It is designed to facilitate performance evaluations by allowing different backend stores to be swapped in and benchmarked under consistent API semantics. The repository contains the application code, configuration, and supporting utilities necessary to run comparative tests across cache backends.


### PR DESCRIPTION
## Summary
- add a repository README explaining the HTTP cache endpoints and multiple backend stores used for performance testing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f652add93c832284b68befe045ab00