### PR TITLE
Add DynamoDB implementation for cache DAO

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,21 +13,34 @@
 	<version>0.0.1-SNAPSHOT</version>
 	<name>cache</name>
 	<description>First Project</description>
-	<properties>
-		<java.version>17</java.version>
-	</properties>
+        <properties>
+                <java.version>17</java.version>
+                <aws.sdk.version>2.20.160</aws.sdk.version>
+        </properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+
+                <dependency>
+                        <groupId>software.amazon.awssdk</groupId>
+                        <artifactId>dynamodb</artifactId>
+                        <version>${aws.sdk.version}</version>
+                </dependency>
+
+                <dependency>
+                        <groupId>software.amazon.awssdk</groupId>
+                        <artifactId>url-connection-client</artifactId>
+                        <version>${aws.sdk.version}</version>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/com/example/cache/config/DynamoDbConfig.java
+++ b/src/main/java/com/example/cache/config/DynamoDbConfig.java
@@ -1,0 +1,51 @@
+package com.example.cache.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+
+import java.net.URI;
+import java.util.Optional;
+
+@Configuration
+@Profile("dynamodb")
+public class DynamoDbConfig {
+
+    @Bean
+    public DynamoDbClient dynamoDbClient(
+            @Value("${cache.dynamodb.region}") String region,
+            @Value("${cache.dynamodb.endpoint:}") String endpoint,
+            AwsCredentialsProvider credentialsProvider,
+            SdkHttpClient sdkHttpClient) {
+
+        DynamoDbClient.Builder builder = DynamoDbClient.builder()
+                .region(Region.of(region))
+                .credentialsProvider(credentialsProvider)
+                .httpClient(sdkHttpClient);
+
+        Optional.ofNullable(endpoint)
+                .filter(e -> !e.isBlank())
+                .map(URI::create)
+                .ifPresent(builder::endpointOverride);
+
+        return builder.build();
+    }
+
+    @Bean
+    public AwsCredentialsProvider awsCredentialsProvider() {
+        return DefaultCredentialsProvider.create();
+    }
+
+    @Bean
+    public SdkHttpClient sdkHttpClient() {
+        return UrlConnectionHttpClient.create();
+    }
+}
+

--- a/src/main/java/com/example/cache/controller/CacheController.java
+++ b/src/main/java/com/example/cache/controller/CacheController.java
@@ -3,7 +3,6 @@ package com.example.cache.controller;
 import java.util.Map;
 
 import com.example.cache.dao.CacheDao;
-import com.example.cache.dao.impl.HashMapCacheDao;
 import com.example.cache.dto.KeyValuePair;
 import com.example.cache.exception.KeyNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/example/cache/dao/impl/DynamoDbCacheDao.java
+++ b/src/main/java/com/example/cache/dao/impl/DynamoDbCacheDao.java
@@ -1,0 +1,78 @@
+package com.example.cache.dao.impl;
+
+import com.example.cache.dao.CacheDao;
+import com.example.cache.exception.KeyNotFoundException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+@Profile("dynamodb")
+public class DynamoDbCacheDao implements CacheDao {
+
+    private static final String DEFAULT_VALUE_ATTRIBUTE = "cacheValue";
+    private static final String DEFAULT_KEY_ATTRIBUTE = "cacheKey";
+
+    private final DynamoDbClient dynamoDbClient;
+    private final String tableName;
+    private final String keyAttribute;
+    private final String valueAttribute;
+
+    public DynamoDbCacheDao(
+            DynamoDbClient dynamoDbClient,
+            @Value("${cache.dynamodb.table-name}") String tableName,
+            @Value("${cache.dynamodb.key-attribute:}" ) String keyAttribute,
+            @Value("${cache.dynamodb.value-attribute:}" ) String valueAttribute) {
+        this.dynamoDbClient = dynamoDbClient;
+        this.tableName = tableName;
+        this.keyAttribute = keyAttribute == null || keyAttribute.isBlank() ? DEFAULT_KEY_ATTRIBUTE : keyAttribute;
+        this.valueAttribute = valueAttribute == null || valueAttribute.isBlank() ? DEFAULT_VALUE_ATTRIBUTE : valueAttribute;
+    }
+
+    @Override
+    public void put(String key, String value) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put(keyAttribute, AttributeValue.builder().s(key).build());
+        item.put(valueAttribute, AttributeValue.builder().s(value).build());
+
+        PutItemRequest putItemRequest = PutItemRequest.builder()
+                .tableName(tableName)
+                .item(item)
+                .build();
+
+        dynamoDbClient.putItem(putItemRequest);
+    }
+
+    @Override
+    public String get(String key) throws KeyNotFoundException {
+        Map<String, AttributeValue> keyMap = Map.of(
+                keyAttribute, AttributeValue.builder().s(key).build()
+        );
+
+        GetItemRequest getItemRequest = GetItemRequest.builder()
+                .tableName(tableName)
+                .key(keyMap)
+                .consistentRead(true)
+                .build();
+
+        GetItemResponse response = dynamoDbClient.getItem(getItemRequest);
+
+        if (response.hasItem()) {
+            return Optional.ofNullable(response.item().get(valueAttribute))
+                    .map(AttributeValue::s)
+                    .orElseThrow(() -> new KeyNotFoundException(key));
+        }
+
+        throw new KeyNotFoundException(key);
+    }
+}
+

--- a/src/main/java/com/example/cache/dao/impl/HashMapCacheDao.java
+++ b/src/main/java/com/example/cache/dao/impl/HashMapCacheDao.java
@@ -2,12 +2,14 @@ package com.example.cache.dao.impl;
 
 import com.example.cache.dao.CacheDao;
 import com.example.cache.exception.KeyNotFoundException;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
 import java.util.Map;
 
 @Component
+@Profile("!dynamodb")
 public class HashMapCacheDao implements CacheDao {
 
     private Map<String, String> map = new HashMap<>();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,7 @@
 
+# DynamoDB configuration (active when the 'dynamodb' profile is enabled)
+# cache.dynamodb.table-name=cache-table
+# cache.dynamodb.region=us-east-1
+# cache.dynamodb.endpoint=http://localhost:4566
+# cache.dynamodb.key-attribute=cacheKey
+# cache.dynamodb.value-attribute=cacheValue


### PR DESCRIPTION
## Summary
- add a DynamoDB-backed CacheDao implementation that can be enabled with the `dynamodb` Spring profile
- provide DynamoDB client configuration and supporting application properties
- include AWS SDK dependencies while keeping the existing HashMap DAO as the default implementation

## Testing
- mvn -q test *(fails: Unable to download Spring Boot parent POM due to 403 from Maven Central in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f651a7d69c832293bd84e7fe3798f7