### PR TITLE
Use qualified HashMap cache DAO in controller

### DIFF
--- a/src/main/java/com/example/cache/controller/CacheController.java
+++ b/src/main/java/com/example/cache/controller/CacheController.java
@@ -3,18 +3,20 @@ package com.example.cache.controller;
 import java.util.Map;
 
 import com.example.cache.dao.CacheDao;
-import com.example.cache.dao.impl.HashMapCacheDao;
 import com.example.cache.dto.KeyValuePair;
 import com.example.cache.exception.KeyNotFoundException;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 public class CacheController {
 
-    @Autowired
-    private CacheDao cacheDao;
+    private final CacheDao cacheDao;
+
+    public CacheController(@Qualifier("hashMapCacheDao") CacheDao cacheDao) {
+        this.cacheDao = cacheDao;
+    }
 
     @PostMapping("/put")
     @ResponseStatus(HttpStatus.CREATED)


### PR DESCRIPTION
## Summary
- inject the HashMap-backed cache DAO into the controller using a qualified bean
- rely on implicit constructor injection so the redundant `@Autowired` annotation is not needed

## Testing
- mvn -q test *(fails: Unable to download parent POM due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68f651fa22688322b8a25109612fac9c